### PR TITLE
Add Bcrypt Hash Provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # identity-hash-provider-bcrypt
-This contains the implementation of Bcrypt hash provider.
+This contains the implementation of bcrypt hash provider

--- a/components/org.wso2.carbon.identity.hash.provider.bcrypt/pom.xml
+++ b/components/org.wso2.carbon.identity.hash.provider.bcrypt/pom.xml
@@ -1,0 +1,207 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2021, WSO2 Inc. (http://www.wso2.com)
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <groupId>org.wso2.carbon.identity.hash.provider.pbkdf2</groupId>
+        <artifactId>identity-hash-provider-bcrypt</artifactId>
+        <version>0.1.7</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>bcrypt</artifactId>
+    <packaging>bundle</packaging>
+    <name>WSO2 Carbon - Bcrypt</name>
+    <description>PBKDF2 password hashing algorithm service</description>
+    <url>http://wso2.org</url>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>org.apache.felix.scr.ds-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon</groupId>
+            <artifactId>org.wso2.carbon.user.core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.osgi</groupId>
+            <artifactId>org.eclipse.osgi.services</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.osgi</groupId>
+            <artifactId>org.eclipse.osgi</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.wso2.orbit.org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk18on</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.orbit.org.bouncycastle</groupId>
+            <artifactId>bcpkix-jdk18on</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.ops4j.pax.logging</groupId>
+            <artifactId>pax-logging-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+        </dependency>
+
+        <!-- Testing related dependencies -->
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jacoco</groupId>
+            <artifactId>org.jacoco.agent</artifactId>
+            <classifier>runtime</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-api-mockito</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <private-package>org.wso2.carbon.identity.hash.provider.bcrypt.internal</private-package>
+                        <Export-Package>
+                            !org.wso2.carbon.identity.hash.provider.bcrypt.internal,
+                            org.wso2.carbon.identity.hash.provider.bcrypt.*
+                        </Export-Package>
+                        <Import-Package>
+                            javax.crypto,
+                            javax.crypto.spec,
+                            org.apache.commons.logging; version = "${import.package.version.commons.logging}",
+                            org.osgi.framework; version = "${osgi.framework.imp.pkg.version.range}",
+                            org.osgi.service.component; version = "${osgi.service.component.imp.pkg.version.range}",
+                            org.wso2.carbon.user.core.exceptions; version = "${carbon.kernel.package.import.version.range}",
+                            org.wso2.carbon.user.core.hash; version = "${carbon.kernel.package.import.version.range}",
+                            org.bouncycastle.crypto.generators.*;version="[1.6,2.0)"
+                        </Import-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${maven.surefire.plugin.version}</version>
+                <configuration>
+                    <suiteXmlFiles>
+                        <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>
+                    </suiteXmlFiles>
+                    <systemPropertyVariables>
+                        <jacoco-agent.destfile>target/jacoco.exec</jacoco-agent.destfile>
+                    </systemPropertyVariables>
+                    <reuseForks>true</reuseForks>
+                    <classpathDependencyExcludes>
+                        <classpathDependencyExclude>org.ops4j.pax.logging</classpathDependencyExclude>
+                    </classpathDependencyExcludes>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco.version}</version>
+                <executions>
+                    <execution>
+                        <id>default-instrument</id>
+                        <goals>
+                            <goal>instrument</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-restore-instrumented-classes</id>
+                        <goals>
+                            <goal>restore-instrumented-classes</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-report</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-report-integration</id>
+                        <goals>
+                            <goal>report-integration</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <rule implementation="org.jacoco.maven.RuleConfiguration">
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit implementation="org.jacoco.report.check.Limit">
+                                            <counter>COMPLEXITY</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>0.60</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+                <configuration>
+                    <threshold>High</threshold>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/components/org.wso2.carbon.identity.hash.provider.bcrypt/src/main/java/org/wso2/carbon/identity/hash/provider/bcrypt/BcryptHashProvider.java
+++ b/components/org.wso2.carbon.identity.hash.provider.bcrypt/src/main/java/org/wso2/carbon/identity/hash/provider/bcrypt/BcryptHashProvider.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2025, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.identity.hash.provider.bcrypt;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.bouncycastle.crypto.generators.OpenBSDBCrypt;
+import org.wso2.carbon.identity.hash.provider.bcrypt.constant.Constants;
+import org.wso2.carbon.user.core.exceptions.HashProviderClientException;
+import org.wso2.carbon.user.core.exceptions.HashProviderException;
+import org.wso2.carbon.user.core.exceptions.HashProviderServerException;
+import org.wso2.carbon.user.core.hash.HashProvider;
+
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+
+
+/**
+ * BCrypt password hashing implementation using OpenBSDBCrypt.
+ */
+public class BcryptHashProvider implements HashProvider {
+
+    private static final Log log = LogFactory.getLog(BcryptHashProvider.class);
+    private static final SecureRandom secureRandom = new SecureRandom();
+
+    private int costFactor;
+    private String version;
+
+    @Override
+    public void init() {
+        costFactor = Constants.DEFAULT_COST_FACTOR;
+        version = Constants.DEFAULT_BCRYPT_VERSION;
+    }
+
+    @Override
+    public void init(Map<String, Object> initProperties) throws HashProviderException {
+        init();
+        Object costFactorObject = initProperties.get(Constants.COST_FACTOR_PROPERTY);
+        Object versionObject = initProperties.get(Constants.VERSION_PROPERTY);
+
+        if (costFactorObject != null) {
+            try {
+                costFactor = Integer.parseInt(costFactorObject.toString());
+                validateCostFactor(costFactor);
+            } catch (NumberFormatException e) {
+                throw new HashProviderClientException(
+                        "BCrypt cost factor must be an integer between 4-31. Got: " + costFactorObject, e);
+            }
+        }
+
+        if (versionObject != null) {
+            try {
+                version = versionObject.toString();
+                validateVersion(version);
+            } catch (Exception e) {
+                throw new HashProviderClientException(
+                        "BCrypt version must be a supported string ('2a', '2y', or '2b'). Got: " + versionObject, e);
+            }
+        }
+    }
+
+    @Override
+    public byte[] calculateHash(char[] plainText, String salt) throws HashProviderException {
+        validatePassword(plainText);
+
+        int byteLength = getUtf8ByteLength(plainText);
+        if (byteLength > Constants.BCRYPT_MAX_PLAINTEXT_LENGTH) {
+            throw new HashProviderClientException(
+                    "Password exceeds BCrypt's 72-byte limit. Length: " + byteLength + " bytes");
+        }
+
+        try {
+            byte[] saltBytes;
+
+            if (StringUtils.isNotEmpty(salt)) {
+                saltBytes = Base64.getDecoder().decode(salt);
+                if (saltBytes.length != Constants.BCRYPT_SALT_LENGTH) {
+                    throw new HashProviderClientException(
+                            "Salt must be exactly 16 bytes when decoded. Got: " + saltBytes.length + " bytes");
+                }
+            } else {
+                String msg = "A salt must be provided for hashing.";
+                log.error(msg);
+                throw new HashProviderClientException(msg);
+            }
+
+            String bcryptHash = OpenBSDBCrypt.generate(version, plainText, saltBytes, costFactor);
+
+            if (log.isDebugEnabled()) {
+                log.debug("Generated BCrypt hash: " + bcryptHash);
+                log.debug("Hash length: " + bcryptHash.length() + " characters");
+            }
+
+            return bcryptHash.getBytes(StandardCharsets.UTF_8);
+
+        } catch (IllegalArgumentException e) {
+            String msg = "Invalid input for BCrypt hashing.";
+            log.error(msg, e);
+            throw new HashProviderClientException(msg, e);
+        } catch (Exception e) {
+            String msg = "Error generating BCrypt hash";
+            log.error(msg, e);
+            throw new HashProviderServerException(msg, e);
+        }
+    }
+
+    @Override
+    public Map<String, Object> getParameters() {
+        Map<String, Object> params = new HashMap<>();
+        params.put(Constants.COST_FACTOR_PROPERTY, costFactor);
+        params.put(Constants.VERSION_PROPERTY, version);
+        return params;
+    }
+
+    @Override
+    public String getAlgorithm() {
+        return Constants.BCRYPT_HASHING_ALGORITHM;
+    }
+
+    /**
+     * Validate cost factor is within acceptable bounds (4-31)
+     */
+    private void validateCostFactor(int costFactor) throws HashProviderClientException {
+        if (costFactor < 4) {
+            throw new HashProviderClientException(
+                    "BCrypt cost factor too low (minimum: 4). Low values compromise security.");
+        }
+        if (costFactor > 31) {
+            throw new HashProviderClientException(
+                    "BCrypt cost factor too high (maximum: 31). High values impact performance.");
+        }
+    }
+
+    /**
+     * Validate BCrypt version is supported
+     */
+    private void validateVersion(String version) throws HashProviderClientException {
+        if (version == null || (!version.equals("2a") && !version.equals("2y") && !version.equals("2b"))) {
+            throw new HashProviderClientException(
+                    "Unsupported BCrypt version. Must be '2a', '2y', or '2b'. Got: " + version);
+        }
+    }
+
+    /**
+     * Validate password is not null or empty
+     */
+    private void validatePassword(char[] plainText) throws HashProviderClientException {
+        if (plainText == null || plainText.length == 0) {
+            throw new HashProviderClientException("Password cannot be null or empty");
+        }
+    }
+
+    /**
+     * Calculate UTF-8 byte length of password
+     */
+    private int getUtf8ByteLength(char[] chars) {
+        if (chars == null || chars.length == 0) {
+            return 0;
+        }
+        return new String(chars).getBytes(StandardCharsets.UTF_8).length;
+    }
+}

--- a/components/org.wso2.carbon.identity.hash.provider.bcrypt/src/main/java/org/wso2/carbon/identity/hash/provider/bcrypt/BcryptHashProviderFactory.java
+++ b/components/org.wso2.carbon.identity.hash.provider.bcrypt/src/main/java/org/wso2/carbon/identity/hash/provider/bcrypt/BcryptHashProviderFactory.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2025, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.hash.provider.bcrypt;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.wso2.carbon.identity.hash.provider.bcrypt.constant.Constants;
+import org.wso2.carbon.user.core.exceptions.HashProviderException;
+import org.wso2.carbon.user.core.hash.HashProvider;
+import org.wso2.carbon.user.core.hash.HashProviderFactory;
+
+/**
+ * The class contains the implementation of Bcrypt HashProvider Factory.
+ */
+public class BcryptHashProviderFactory implements HashProviderFactory {
+
+    @Override
+    public HashProvider getHashProvider() {
+        BcryptHashProvider bcryptHashProvider = new BcryptHashProvider();
+        bcryptHashProvider.init();
+        return bcryptHashProvider;
+    }
+
+    @Override
+    public HashProvider getHashProvider(Map<String, Object> initProperties) throws HashProviderException {
+        BcryptHashProvider bcryptHashProvider = new BcryptHashProvider();
+        bcryptHashProvider.init(initProperties);
+        return bcryptHashProvider;
+    }
+
+    @Override
+    public Set<String> getHashProviderConfigProperties() {
+        Set<String> metaProperties = new HashSet<>();
+        metaProperties.add(Constants.COST_FACTOR_PROPERTY);
+        return metaProperties;
+    }
+
+    @Override
+    public String getAlgorithm() {
+        return Constants.BCRYPT_HASHING_ALGORITHM;
+    }
+}

--- a/components/org.wso2.carbon.identity.hash.provider.bcrypt/src/main/java/org/wso2/carbon/identity/hash/provider/bcrypt/ErrorMessage.java
+++ b/components/org.wso2.carbon.identity.hash.provider.bcrypt/src/main/java/org/wso2/carbon/identity/hash/provider/bcrypt/ErrorMessage.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.hash.provider.bcrypt;
+
+/**
+ * The ENUM includes all the error messages of hashing.
+ */
+public enum ErrorMessage {
+
+    // Client Errors.
+    ERROR_CODE_EMPTY_VALUE("60001", "Empty value", "Value cannot be empty"),
+    ERROR_CODE_INVALID_ITERATION_COUNT("60002", "Invalid iteration count",
+            "Iteration count should be a positive integer"),
+    ERROR_CODE_INVALID_DERIVED_KEY_LENGTH("60003", "invalid derived key length",
+            "Derived key length should be a positive integer"),
+
+    // Server Errors.
+    ERROR_CODE_NO_SUCH_ALGORITHM("65001", "Unsupported pseudo random function.",
+            "PRF: %s was not supported by Secret Key Factory."),
+    ERROR_CODE_INVALID_KEY_SPEC("65002", "Secret key cannot be generated.",
+            "Secret key cannot be generated from SecretKeyFactory"),
+    ERROR_CODE_EMPTY_SALT_VALUE("65003", "Invalid salt value", "Salt value cannot be blank");
+
+    private final String code;
+    private final String message;
+    private final String description;
+
+    ErrorMessage(String code, String message, String description) {
+
+        this.code = code;
+        this.message = message;
+        this.description = description;
+    }
+
+    /**
+     * Get the error code.
+     *
+     * @return Error code without the scenario prefix.
+     */
+    public String getCode() {
+
+        return code;
+    }
+
+    /**
+     * Get error message.
+     *
+     * @return Error scenario message.
+     */
+    public String getMessage() {
+
+        return message;
+    }
+
+    /**
+     * Get error scenario description.
+     *
+     * @return Error scenario description.
+     */
+    public String getDescription() {
+
+        return description;
+    }
+
+    @Override
+    public String toString() {
+
+        return getCode() + " | " + getMessage() + " | " + getDescription();
+    }
+}

--- a/components/org.wso2.carbon.identity.hash.provider.bcrypt/src/main/java/org/wso2/carbon/identity/hash/provider/bcrypt/constant/Constants.java
+++ b/components/org.wso2.carbon.identity.hash.provider.bcrypt/src/main/java/org/wso2/carbon/identity/hash/provider/bcrypt/constant/Constants.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2025, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.hash.provider.bcrypt.constant;
+
+/**
+ * This class contains constants.
+ */
+public class Constants {
+
+    public static final String BCRYPT_HASH_PROVIDER_ERROR_PREFIX = "BC-";
+
+    public static final String COST_FACTOR_PROPERTY = "bcrypt.cost.factor";
+    public static final String VERSION_PROPERTY = "bcrypt.version";
+    public static final String BCRYPT_HASHING_ALGORITHM = "BCRYPT";
+    public static final int DEFAULT_COST_FACTOR = 12;
+    public static final int BCRYPT_MAX_PLAINTEXT_LENGTH = 72;
+    public static final int BCRYPT_SALT_LENGTH = 16;
+    public static final String DEFAULT_BCRYPT_VERSION= "2b";
+
+}

--- a/components/org.wso2.carbon.identity.hash.provider.bcrypt/src/main/java/org/wso2/carbon/identity/hash/provider/bcrypt/internal/BcryptHashServiceComponent.java
+++ b/components/org.wso2.carbon.identity.hash.provider.bcrypt/src/main/java/org/wso2/carbon/identity/hash/provider/bcrypt/internal/BcryptHashServiceComponent.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.hash.provider.bcrypt.internal;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.osgi.service.component.ComponentContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.wso2.carbon.identity.hash.provider.bcrypt.BcryptHashProviderFactory;
+import org.wso2.carbon.user.core.hash.HashProviderFactory;
+
+/**
+ * This class contains the Bcrypt hashing service component.
+ */
+@Component(
+        name = "org.wso2.carbon.identity.hash.provider.bcrypt.component",
+        immediate = true
+)
+public class BcryptHashServiceComponent {
+
+    private static final Log log = LogFactory.getLog(BcryptHashServiceComponent.class);
+
+    @Activate
+    protected void activate(ComponentContext componentContext) {
+
+        try {
+            HashProviderFactory hashProviderFactory = new BcryptHashProviderFactory();
+            componentContext.getBundleContext().registerService(HashProviderFactory.class.getName(),
+                    hashProviderFactory, null);
+
+            if (log.isDebugEnabled()) {
+                log.debug("Bcrypt bundle activated successfully.");
+            }
+        } catch (Throwable e) {
+            log.error("Failed to activate Bcrypt bundle", e);
+        }
+    }
+
+    @Deactivate
+    protected void deactivate(ComponentContext componentContext) {
+
+        if (log.isDebugEnabled()) {
+            log.debug("Bcrypt bundle is deactivated.");
+        }
+    }
+}

--- a/components/org.wso2.carbon.identity.hash.provider.bcrypt/src/test/java/org/wso2/carbon/identity/hash/provider/bcrypt/BcryptHashProviderFactoryTest.java
+++ b/components/org.wso2.carbon.identity.hash.provider.bcrypt/src/test/java/org/wso2/carbon/identity/hash/provider/bcrypt/BcryptHashProviderFactoryTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.hash.provider.bcrypt;
+
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.hash.provider.bcrypt.constant.Constants;
+import org.wso2.carbon.user.core.exceptions.HashProviderException;
+import org.wso2.carbon.user.core.hash.HashProvider;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Test class for BcryptHashProviderFactory.
+ */
+public class BcryptHashProviderFactoryTest {
+
+    private static BcryptHashProviderFactory bcryptHashProviderFactory = null;
+    private static HashProvider bcryptHashProvider = null;
+
+    @BeforeClass
+    public void initialize() {
+
+        bcryptHashProviderFactory = new BcryptHashProviderFactory();
+    }
+
+    @Test
+    public void testGetConfigProperties() {
+
+        Set<String> metaPropertiesActual = bcryptHashProviderFactory.getHashProviderConfigProperties();
+        Set<String> metaPropertiesExpected = new HashSet<>();
+        metaPropertiesExpected.add(Constants.COST_FACTOR_PROPERTY);
+        Assert.assertEquals(metaPropertiesActual, metaPropertiesExpected);
+    }
+
+    @Test
+    public void testGetAlgorithm() {
+
+        Assert.assertEquals(bcryptHashProviderFactory.getAlgorithm(), Constants.BCRYPT_HASHING_ALGORITHM);
+    }
+
+    @Test
+    public void testGetHashProviderWithDefaultParams() {
+
+        bcryptHashProvider = bcryptHashProviderFactory.getHashProvider();
+        Map<String, Object> bcryptParamsMap = bcryptHashProvider.getParameters();
+        Assert.assertEquals(bcryptParamsMap.get(Constants.COST_FACTOR_PROPERTY), Constants.DEFAULT_COST_FACTOR);
+    }
+
+    @DataProvider(name = "getHashProviderWithParams")
+    public Object[][] getHashProviderWithParams() {
+
+        return new Object[][]{
+                {"10"},
+                {"12"},
+                {"14"}
+        };
+    }
+
+    @Test(dataProvider = "getHashProviderWithParams")
+    public void testGetHashProviderWithParams(String costFactor)
+            throws HashProviderException {
+
+        Map<String, Object> bcryptParams = new HashMap<>();
+        bcryptParams.put(Constants.COST_FACTOR_PROPERTY, costFactor);
+        bcryptHashProvider = bcryptHashProviderFactory.getHashProvider(bcryptParams);
+        Assert.assertEquals(bcryptHashProvider.getParameters().get(Constants.COST_FACTOR_PROPERTY),
+                Integer.parseInt(costFactor));
+    }
+}

--- a/components/org.wso2.carbon.identity.hash.provider.bcrypt/src/test/java/org/wso2/carbon/identity/hash/provider/bcrypt/BcryptHashProviderTest.java
+++ b/components/org.wso2.carbon.identity.hash.provider.bcrypt/src/test/java/org/wso2/carbon/identity/hash/provider/bcrypt/BcryptHashProviderTest.java
@@ -1,0 +1,164 @@
+
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.identity.hash.provider.bcrypt;
+
+import org.bouncycastle.crypto.generators.OpenBSDBCrypt;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.wso2.carbon.identity.hash.provider.bcrypt.constant.Constants;
+import org.wso2.carbon.user.core.exceptions.HashProviderClientException;
+import org.wso2.carbon.user.core.exceptions.HashProviderException;
+
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Test class for BcryptHashProvider.
+ */
+public class BcryptHashProviderTest {
+
+    private static BcryptHashProvider bcryptHashProvider = null;
+    private static final SecureRandom random = new SecureRandom();
+
+    @BeforeClass
+    public void initialize() {
+
+        bcryptHashProvider = new BcryptHashProvider();
+    }
+
+    @Test
+    public void testInitWithDefaultCostFactor() {
+
+        bcryptHashProvider.init();
+        Map<String, Object> params = bcryptHashProvider.getParameters();
+        Assert.assertEquals(params.get(Constants.COST_FACTOR_PROPERTY),
+                Constants.DEFAULT_COST_FACTOR);
+    }
+
+    @DataProvider(name = "initConfigParams")
+    public Object[][] initConfigParams() {
+        return new Object[][]{
+                {"10"},
+                {"12"},
+                {"14"}
+        };
+    }
+
+    @Test(dataProvider = "initConfigParams")
+    public void testInitWithCustomCostFactor(String costFactor) throws HashProviderException {
+        Map<String, Object> initProperties = new HashMap<>();
+        initProperties.put(Constants.COST_FACTOR_PROPERTY, costFactor);
+        bcryptHashProvider.init(initProperties);
+        Map<String, Object> params = bcryptHashProvider.getParameters();
+        Assert.assertEquals(params.get(Constants.COST_FACTOR_PROPERTY),
+                Integer.parseInt(costFactor));
+    }
+
+    @Test(expectedExceptions = HashProviderClientException.class,
+            expectedExceptionsMessageRegExp = "Invalid value for the Bcrypt cost factor. It must be an integer.")
+    public void testInitWithInvalidCostFactorType() throws HashProviderException {
+        Map<String, Object> initProperties = new HashMap<>();
+        initProperties.put(Constants.COST_FACTOR_PROPERTY, "invalid_string");
+        bcryptHashProvider.init(initProperties);
+    }
+
+    @Test(expectedExceptions = HashProviderClientException.class,
+            expectedExceptionsMessageRegExp = "Bcrypt cost factor must be a positive integer.")
+    public void testInitWithZeroCostFactor() throws HashProviderException {
+        Map<String, Object> initProperties = new HashMap<>();
+        initProperties.put(Constants.COST_FACTOR_PROPERTY, "0");
+        bcryptHashProvider.init(initProperties);
+    }
+
+    @DataProvider(name = "getHash")
+    public Object[][] getHash() {
+        byte[] salt1 = new byte[16];
+        random.nextBytes(salt1);
+        String base64Salt1 = Base64.getEncoder().encodeToString(salt1);
+
+        byte[] salt2 = new byte[16];
+        random.nextBytes(salt2);
+        String base64Salt2 = Base64.getEncoder().encodeToString(salt2);
+
+        return new Object[][]{
+                {"test1234".toCharArray(), base64Salt1, 12},
+                {"password".toCharArray(), base64Salt2, 10}
+        };
+    }
+
+    @Test(dataProvider = "getHash")
+    public void testCalculateHash(char[] plainText, String salt, int costFactor)
+            throws HashProviderException {
+        Map<String, Object> initProperties = new HashMap<>();
+        initProperties.put(Constants.COST_FACTOR_PROPERTY, String.valueOf(costFactor));
+        bcryptHashProvider.init(initProperties);
+
+        byte[] calculatedHashBytes = bcryptHashProvider.calculateHash(plainText, salt);
+        String calculatedHash = new String(calculatedHashBytes, StandardCharsets.UTF_8);
+
+        boolean isVerified = OpenBSDBCrypt.checkPassword(calculatedHash, plainText);
+        Assert.assertTrue(isVerified,
+                "The calculated hash should be valid for the given password.");
+    }
+
+    @DataProvider(name = "hashProviderErrorScenarios")
+    public Object[][] hashProviderErrorScenarios() {
+        return new Object[][]{
+                // Password length greater than 72 characters.
+                {"thispasswordiswaytoolongtobeusedinabacryptanditshouldbevalidatedandthrownanerror".toCharArray(),
+                        "a16bytelongsalt1", "Password length exceeds the maximum allowed by Bcrypt (72 characters)."},
+                // Invalid Base64 salt.
+                {"test1234".toCharArray(), "short", "Invalid Base64 salt provided."},
+                // Incorrect salt length (16 bytes required).
+                {"test1234".toCharArray(), Base64.getEncoder().encodeToString
+                        ("15bytelongsalt_".getBytes(StandardCharsets.UTF_8)),
+                        "Salt length is not 16 bytes, but is 15."},
+        };
+    }
+
+    @Test(dataProvider = "hashProviderErrorScenarios")
+    public void testHashProviderErrorScenarios(char[] plainText, String salt, String expectedMessage) {
+        try {
+            if (expectedMessage.contains("cost factor")) {
+                Map<String, Object> initProperties = new HashMap<>();
+                initProperties.put(Constants.COST_FACTOR_PROPERTY, "0");
+                bcryptHashProvider.init(initProperties);
+            } else {
+                bcryptHashProvider.init();
+            }
+            bcryptHashProvider.calculateHash(plainText, salt);
+            Assert.fail("Expected a HashProviderException but no exception was thrown.");
+        } catch (HashProviderException e) {
+            Assert.assertEquals(e.getMessage(), expectedMessage,
+                    "Unexpected error message.");
+        }
+    }
+
+    @Test
+    public void testGetAlgorithm() {
+        Assert.assertEquals(bcryptHashProvider.getAlgorithm(),
+                Constants.BCRYPT_HASHING_ALGORITHM);
+    }
+}

--- a/components/org.wso2.carbon.identity.hash.provider.bcrypt/src/test/resources/testng.xml
+++ b/components/org.wso2.carbon.identity.hash.provider.bcrypt/src/test/resources/testng.xml
@@ -1,0 +1,28 @@
+<!--
+  ~ Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+
+<suite name="org.wso2.carbon.identity.hash.provider.bcrypt">
+    <test name="org.wso2.carbon.identity.hash.provider.bcrypt" preserve-order="false" parallel="false">
+        <classes>
+            <class name="org.wso2.carbon.identity.hash.provider.bcrypt.BcryptHashProviderTest"/>
+            <class name="org.wso2.carbon.identity.hash.provider.bcrypt.BcryptHashProviderFactoryTest"/>
+        </classes>
+    </test>
+</suite>

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,298 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <parent>
+        <groupId>org.wso2</groupId>
+        <artifactId>wso2</artifactId>
+        <version>1.4</version>
+    </parent>
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.wso2.carbon.identity.hash.provider.pbkdf2</groupId>
+    <artifactId>identity-hash-provider-bcrypt</artifactId>
+    <version>0.1.7</version>
+    <packaging>pom</packaging>
+    <name>WSO2 Carbon Bcrypt module</name>
+    <url>http://wso2.org</url>
+
+    <scm>
+        <connection>scm:git:https://github.com/wso2-extensions/identity-hash-provider-pbkdf2.git</connection>
+        <developerConnection>scm:git:https://github.com/wso2-extensions/identity-hash-provider-pbkdf2.git</developerConnection>
+        <url>https://github.com/wso2-extensions/identity-hash-provider-pbkdf2.git</url>
+        <tag>v0.1.7</tag>
+    </scm>
+
+    <modules>
+        <module>components/org.wso2.carbon.identity.hash.provider.bcrypt</module>
+    </modules>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.wso2.orbit.org.bouncycastle</groupId>
+                <artifactId>bcprov-jdk18on</artifactId>
+                <version>${bcprov-jdk18.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.orbit.org.bouncycastle</groupId>
+                <artifactId>bcpkix-jdk18on</artifactId>
+                <version>${bcpkix-jdk18.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>org.apache.felix.scr.ds-annotations</artifactId>
+                <version>${org.apache.felix.scr.ds-annotations.version}</version>
+                <scope>provided</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon</groupId>
+                <artifactId>org.wso2.carbon.user.core</artifactId>
+                <version>${carbon.kernel.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.osgi</groupId>
+                <artifactId>org.eclipse.osgi.services</artifactId>
+                <version>${org.eclipse.osgi.services.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.osgi</groupId>
+                <artifactId>org.eclipse.osgi</artifactId>
+                <version>${org.eclipse.osgi.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.ops4j.pax.logging</groupId>
+                <artifactId>pax-logging-api</artifactId>
+                <version>${pax-logging-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-logging</groupId>
+                <artifactId>commons-logging</artifactId>
+                <version>${commons.logging.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.hash.provider.pbkdf2</groupId>
+                <artifactId>bcrypt</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.wso2.carbon.identity.hash.provider.pbkdf2</groupId>
+                <artifactId>feature</artifactId>
+                <version>${project.version}</version>
+                <type>zip</type>
+            </dependency>
+
+            <!-- Testing related dependencies -->
+            <dependency>
+                <groupId>org.testng</groupId>
+                <artifactId>testng</artifactId>
+                <version>${testng.version}</version>
+                <scope>test</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jacoco</groupId>
+                <artifactId>org.jacoco.agent</artifactId>
+                <classifier>runtime</classifier>
+                <version>${jacoco.version}</version>
+                <scope>test</scope>
+
+            </dependency>
+
+
+
+            <dependency>
+                <groupId>org.powermock</groupId>
+                <artifactId>powermock-module-testng</artifactId>
+                <version>${org.powermock.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.powermock</groupId>
+                <artifactId>powermock-api-mockito</artifactId>
+                <version>${org.powermock.version}</version>
+                <scope>test</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.felix</groupId>
+                    <artifactId>maven-bundle-plugin</artifactId>
+                    <version>${maven-bundle-plugin.version}</version>
+                    <extensions>true</extensions>
+                    <configuration>
+                        <obrRepository>NONE</obrRepository>
+                        <instructions>
+                            <SCM-Revision>${buildNumber}</SCM-Revision>
+                        </instructions>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>buildnumber-maven-plugin</artifactId>
+                    <version>${maven.buildnumber.plugin.version}</version>
+                    <executions>
+                        <execution>
+                            <phase>validate</phase>
+                            <goals>
+                                <goal>create</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                    <configuration>
+                        <doCheck>false</doCheck>
+                        <doUpdate>false</doUpdate>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>com.github.spotbugs</groupId>
+                    <artifactId>spotbugs-maven-plugin</artifactId>
+                    <version>${spotbugs-maven-plugin.version}</version>
+                    <configuration>
+                        <effort>Max</effort>
+                        <threshold>High</threshold>
+                        <failOnError>true</failOnError>
+                        <maxHeap>1024</maxHeap>
+                        <plugins>
+                            <plugin>
+                                <groupId>com.h3xstream.findsecbugs</groupId>
+                                <artifactId>findsecbugs-plugin</artifactId>
+                                <version>${findsecbugs-plugin.version}</version>
+                            </plugin>
+                        </plugins>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>analyze-compile</id>
+                            <phase>compile</phase>
+                            <goals>
+                                <goal>check</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-checkstyle-plugin</artifactId>
+                    <version>${maven.checkstyleplugin.version}</version>
+                    <executions>
+                        <execution>
+                            <id>validate</id>
+                            <phase>none</phase>
+                            <configuration>
+                                <configLocation>
+                                    https://raw.githubusercontent.com/wso2/code-quality-tools/v1.3/checkstyle/checkstyle.xml
+                                </configLocation>
+                                <suppressionsLocation>
+                                    https://raw.githubusercontent.com/wso2/code-quality-tools/v1.3/checkstyle/suppressions.xml
+                                </suppressionsLocation>
+                                <encoding>UTF-8</encoding>
+                                <consoleOutput>true</consoleOutput>
+                                <failsOnError>true</failsOnError>
+                                <includeTestSourceDirectory>true</includeTestSourceDirectory>
+                            </configuration>
+                            <goals>
+                                <goal>check</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven-compiler-plugin.version}</version>
+                <inherited>true</inherited>
+                <configuration>
+                    <encoding>UTF-8</encoding>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <configuration>
+                    <preparationGoals>clean install</preparationGoals>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>buildnumber-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>com.github.spotbugs</groupId>
+                <artifactId>spotbugs-maven-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-checkstyle-plugin</artifactId>
+            </plugin>
+
+
+
+        </plugins>
+    </build>
+
+    <properties>
+        <import.package.version.commons.logging>[1.2,2)</import.package.version.commons.logging>
+        <osgi.framework.imp.pkg.version.range>[1.7,2)</osgi.framework.imp.pkg.version.range>
+        <osgi.service.component.imp.pkg.version.range>[1.2,2)</osgi.service.component.imp.pkg.version.range>
+
+        <org.apache.felix.scr.ds-annotations.version>1.2.10</org.apache.felix.scr.ds-annotations.version>
+        <carbon.kernel.version>4.6.3-m4</carbon.kernel.version>
+        <carbon.kernel.feature.version>4.6.3</carbon.kernel.feature.version>
+        <org.eclipse.osgi.services.version>3.3.100.v20130513-1956</org.eclipse.osgi.services.version>
+        <org.eclipse.osgi.version>3.9.1.v20130814-1242</org.eclipse.osgi.version>
+        <pax-logging-api.version>1.11.0</pax-logging-api.version>
+        <carbon.kernel.package.import.version.range>[4.6.2, 5.0.0)</carbon.kernel.package.import.version.range>
+        <commons.logging.version>1.2</commons.logging.version>
+
+        <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
+        <maven-bundle-plugin.version>3.2.0</maven-bundle-plugin.version>
+        <maven.buildnumber.plugin.version>1.4</maven.buildnumber.plugin.version>
+        <maven.checkstyleplugin.version>3.1.0</maven.checkstyleplugin.version>
+        <carbon.p2.plugin.version>5.1.2</carbon.p2.plugin.version>
+
+        <bcprov-jdk18.version>1.78.1.wso2v1</bcprov-jdk18.version>
+        <bcpkix-jdk18.version>1.78.1.wso2v1</bcpkix-jdk18.version>
+
+        <!-- Unit test versions -->
+        <testng.version>6.9.10</testng.version>
+        <jacoco.version>0.8.2</jacoco.version>
+        <org.powermock.version>1.7.4</org.powermock.version>
+
+        <!-- Spotbugs versions -->
+        <spotbugs-maven-plugin.version>4.7.3.0</spotbugs-maven-plugin.version>
+        <findsecbugs-plugin.version>1.10.1</findsecbugs-plugin.version>
+    </properties>
+</project>


### PR DESCRIPTION
### Purpose

This pull request is for the identity-hash-provider-bcrypt repo which has the implementation for the Bcrypt hashing algorithm. This pull request introduces Bcrypt password hashing support to the identity-hash-provider module.