### PR TITLE
Fix Server Startup issues in FIPS compliant mode due to not having Bouncy Castle jars

### DIFF
--- a/components/org.wso2.carbon.identity.hash.provider.bcrypt/pom.xml
+++ b/components/org.wso2.carbon.identity.hash.provider.bcrypt/pom.xml
@@ -112,8 +112,8 @@
                             org.osgi.service.component; version = "${osgi.service.component.imp.pkg.version.range}",
                             org.wso2.carbon.user.core.exceptions; version = "${carbon.kernel.package.import.version.range}",
                             org.wso2.carbon.user.core.hash; version = "${carbon.kernel.package.import.version.range}",
-                            org.bouncycastle.crypto.generators.*;version="[1.6,2.0)",
-                            org.bouncycastle.crypto;version="[1.70,2.0)",
+                            org.bouncycastle.crypto.generators.*;version="[1.6,2.0)"; resolution:=optional,
+                            org.bouncycastle.crypto;version="[1.70,2.0)"; resolution:=optional,
                         </Import-Package>
                     </instructions>
                 </configuration>


### PR DESCRIPTION
## Purpose
- Fix Server Startup issues in FIPS compliant mode due to not having Bouncy Castle jars.
- Related Issue: https://github.com/wso2/product-is/issues/27333
